### PR TITLE
Added column-completion option

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -74,9 +74,10 @@ class syntax_plugin_csv extends DokuWiki_Syntax_Plugin {
             'hdr_rows'    => 1,
             'hdr_cols'    => 0,
             'span_empty_cols' => 0,
+            'force_cells' => 0,
             'file'    => '',
             'delim'   => ',',
-            'content' => ''
+            'content' => '',
         );
 
         list($optstr,$opt['content']) = explode('>',$match,2);
@@ -168,6 +169,14 @@ class syntax_plugin_csv extends DokuWiki_Syntax_Plugin {
             $spans = array();
             $span  = 0;
             $current = 0;
+            if ($opt['force_empty_cells']) {
+                if (count($cells) < $maxrow) {
+                    $empty_cells = $maxrow - count($cells);
+                    for ($i = 0; $i <= $empty_cells; ++$i) {
+                        $cells[] = '';
+                    }
+                }
+            }
             foreach($cells as $cell) {
                 if ($cell == '' && $opt['span_empty_cols']) {
                     $spans[$current] = 0;


### PR DESCRIPTION
Added "force_cells" option which causes extra cells to be created on each row
to match $max_rows. Useful if you're exporting from several spreadsheet apps
(including Google Spreadsheets) that don't create cells if you have empty
trailing columns.

So for example, if I have a CSV like this:

<csv>
name,phone,email,im
filipe,4085552345,filipe@mercenary3.com,filrprogger
cosmocode,5145551234,cosmocode@spam.la
</csv>

Because the 3rd line doesn't have a 4th column, the current CSV plugin will not render a 4th column for that row. On longer spreadsheets, this can look pretty ugly. By doing:

<csv force_cells=1>...</csv>

This will now force the CSV plugin to add extra columns to each row up to $max_rows in syntax_plugin_csv::render() so that you end up with a complete table. I can provide an example in action if this doesn't make sense.
