### PR TITLE
Add support for downloading CSV file

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -75,29 +75,29 @@ class syntax_plugin_csv extends DokuWiki_Syntax_Plugin {
         $optsin = explode(' ', $optstr);
         $populate = '';
         foreach($optsin as $o) {
-           $o = trim($o);
-           if ( $populate != '' ) {
-              // handle closing quote
-              $opt[$populate] .= ' ';
-              if ( substr($o, -1) == '"' ) {
-                 $o = substr($o, 0, -1);
-                 $opt[$populate] .= $o;
-                 $populate = '';
-              }
-              else
-                 $opt[$populate] .= $o;
-           }
-           elseif (preg_match('/(\w+)=(.*)/', $o, $matches)) {
-              // strip leading quote
-              if ( substr($matches[2], 0, 1) == '"' ) {
-                 $matches[2] = substr($matches[2], 1, -1);
-                 if ( substr($matches[2], -1) == '"' ) 
-                    $matches[2] = substr($matches[2], 0, -1);
-                 else
-                    $populate = $matches[1];
-              }
-              $opt[$matches[1]] = $matches[2];
-           } elseif($o) {
+            $o = trim($o);
+            if ( $populate != '' ) {
+                // handle closing quote
+                $opt[$populate] .= ' ';
+                if ( substr($o, -1) == '"' ) {
+                    $o = substr($o, 0, -1);
+                    $opt[$populate] .= $o;
+                    $populate = '';
+                }
+                else
+                    $opt[$populate] .= $o;
+            }
+            elseif (preg_match('/(\w+)=(.*)/', $o, $matches)) {
+                // strip leading quote
+                if ( substr($matches[2], 0, 1) == '"' ) {
+                    $matches[2] = substr($matches[2], 1, -1);
+                    if ( substr($matches[2], -1) == '"' ) 
+                        $matches[2] = substr($matches[2], 0, -1);
+                    else
+                        $populate = $matches[1];
+                }
+                $opt[$matches[1]] = $matches[2];
+            } elseif($o) {
                 if(preg_match('/^https?:\/\//i', $o)) {
                     $opt['file'] = $o;
                 } else {
@@ -105,7 +105,7 @@ class syntax_plugin_csv extends DokuWiki_Syntax_Plugin {
                     if(!strlen(getNS($opt['file'])))
                         $opt['file'] = $INFO['namespace'].':'.$opt['file'];
                 }
-           }
+            }
         }
         if($opt['delim'] == 'tab') $opt['delim'] = "\t";
 
@@ -160,17 +160,17 @@ class syntax_plugin_csv extends DokuWiki_Syntax_Plugin {
                 $targetfile = '';
                 return true;
             } else {
-               $file = mediaFN($targetfile);
-               if ( file_put_contents ($file, $content, LOCK_EX) > 0 ) {
-                  $linkname = $opt['linkname'];
-                  if ( $linkname == '' )
-                     $linkname = 'Download CSV file';
-               }
-               else {
-                   $targetfile = '';
-                   $renderer->cdata('Failed to write '.$file.': Could not create download link.');
-                   return true;
-               }
+                $file = mediaFN($targetfile);
+                if ( file_put_contents ($file, $content, LOCK_EX) > 0 ) {
+                    $linkname = $opt['linkname'];
+                    if ( $linkname == '' )
+                        $linkname = 'Download CSV file';
+                }
+                else {
+                    $targetfile = '';
+                    $renderer->cdata('Failed to write '.$file.': Could not create download link.');
+                    return true;
+                }
             }
         }
 
@@ -233,7 +233,7 @@ class syntax_plugin_csv extends DokuWiki_Syntax_Plugin {
         $renderer->table_close();
 
         if ( $targetfile != '' ) 
-           $renderer->internalmedia($targetfile, $linkname);
+            $renderer->internalmedia($targetfile, $linkname);
 
         return true;
     }


### PR DESCRIPTION
Extended plugin to provide this, by adding the options:

import=<file to display>
export=:dokuwiki:media:path:where:to:write:mediafile.csv
linkname=Name of the download link to create

Thus, I changed the syntax to use '|' as delimiter between options
rather than using ' '.  I feel this is "more dokuwiki" :).  However,
this breaks existing dokuwiki pages that use the csv plugin to display
a CVS file, which now would have to replace the separating space (' ')
with '|import='.

The idea behind this extension is that I want to maintain a list (in
my case a member list) in dokuwiki but provide a download link to the
csv file (also for users with only read access to the page).  This is
now supported as shown in the following example:

<csv|export=:media:members.csv|linkname=Download member list>
Name,Email
,
Paul,paul@email.com
Andreads,andreas@dokuwiki.org
</csv>

It renders the CSV data as a DokuWiki table but adds a CSV download link
with the title "Download member list".

This is done in the following way:

When rendering the CSV data, this data is also copied to the export=
file.  Finally, a link to the just generated file is provided.